### PR TITLE
[BREAKING_CHANGES] Changes Definition.Type from DataType to []DataType

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,14 +628,14 @@ Using the `jsonschema` package, this schema could be created using structs as su
 FunctionDefinition{
   Name: "get_current_weather",
   Parameters: jsonschema.Definition{
-    Type: jsonschema.Object,
+    Type: []jsonschema.DataType{jsonschema.Object},
     Properties: map[string]jsonschema.Definition{
       "location": {
-        Type: jsonschema.String,
+        Type: []jsonschema.DataType{jsonschema.String},
         Description: "The city and state, e.g. San Francisco, CA",
       },
       "unit": {
-        Type: jsonschema.String,
+        Type: []jsonschema.DataType{jsonschema.String},
         Enum: []string{"celsius", "fahrenheit"},
       },
     },

--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -91,14 +91,14 @@ func TestAPI(t *testing.T) {
 			Functions: []openai.FunctionDefinition{{
 				Name: "get_current_weather",
 				Parameters: jsonschema.Definition{
-					Type: jsonschema.Object,
+					Type: []jsonschema.DataType{jsonschema.Object},
 					Properties: map[string]jsonschema.Definition{
 						"location": {
-							Type:        jsonschema.String,
+							Type:        []jsonschema.DataType{jsonschema.String},
 							Description: "The city and state, e.g. San Francisco, CA",
 						},
 						"unit": {
-							Type: jsonschema.String,
+							Type: []jsonschema.DataType{jsonschema.String},
 							Enum: []string{"celsius", "fahrenheit"},
 						},
 					},
@@ -273,19 +273,19 @@ func TestChatCompletionStructuredOutputsFunctionCalling(t *testing.T) {
 						Name:   "display_cases",
 						Strict: true,
 						Parameters: &jsonschema.Definition{
-							Type: jsonschema.Object,
+							Type: []jsonschema.DataType{jsonschema.Object},
 							Properties: map[string]jsonschema.Definition{
 								"PascalCase": {
-									Type: jsonschema.String,
+									Type: []jsonschema.DataType{jsonschema.String},
 								},
 								"CamelCase": {
-									Type: jsonschema.String,
+									Type: []jsonschema.DataType{jsonschema.String},
 								},
 								"KebabCase": {
-									Type: jsonschema.String,
+									Type: []jsonschema.DataType{jsonschema.String},
 								},
 								"SnakeCase": {
-									Type: jsonschema.String,
+									Type: []jsonschema.DataType{jsonschema.String},
 								},
 							},
 							Required:             []string{"PascalCase", "CamelCase", "KebabCase", "SnakeCase"},

--- a/chat_test.go
+++ b/chat_test.go
@@ -428,21 +428,21 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Functions: []openai.FunctionDefinition{{
 				Name: "test",
 				Parameters: &jsonschema.Definition{
-					Type: jsonschema.Object,
+					Type: []jsonschema.DataType{jsonschema.Object},
 					Properties: map[string]jsonschema.Definition{
 						"count": {
-							Type:        jsonschema.Number,
+							Type:        []jsonschema.DataType{jsonschema.Number},
 							Description: "total number of words in sentence",
 						},
 						"words": {
-							Type:        jsonschema.Array,
+							Type:        []jsonschema.DataType{jsonschema.Array},
 							Description: "list of words in sentence",
 							Items: &jsonschema.Definition{
-								Type: jsonschema.String,
+								Type: []jsonschema.DataType{jsonschema.String},
 							},
 						},
 						"enumTest": {
-							Type: jsonschema.String,
+							Type: []jsonschema.DataType{jsonschema.String},
 							Enum: []string{"hello", "world"},
 						},
 					},
@@ -465,21 +465,21 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Functions: []openai.FunctionDefine{{
 				Name: "test",
 				Parameters: &jsonschema.Definition{
-					Type: jsonschema.Object,
+					Type: []jsonschema.DataType{jsonschema.Object},
 					Properties: map[string]jsonschema.Definition{
 						"count": {
-							Type:        jsonschema.Number,
+							Type:        []jsonschema.DataType{jsonschema.Number},
 							Description: "total number of words in sentence",
 						},
 						"words": {
-							Type:        jsonschema.Array,
+							Type:        []jsonschema.DataType{jsonschema.Array},
 							Description: "list of words in sentence",
 							Items: &jsonschema.Definition{
-								Type: jsonschema.String,
+								Type: []jsonschema.DataType{jsonschema.String},
 							},
 						},
 						"enumTest": {
-							Type: jsonschema.String,
+							Type: []jsonschema.DataType{jsonschema.String},
 							Enum: []string{"hello", "world"},
 						},
 					},

--- a/examples/completion-with-tool/main.go
+++ b/examples/completion-with-tool/main.go
@@ -15,14 +15,14 @@ func main() {
 
 	// describe the function & its inputs
 	params := jsonschema.Definition{
-		Type: jsonschema.Object,
+		Type: []jsonschema.DataType{jsonschema.Object},
 		Properties: map[string]jsonschema.Definition{
 			"location": {
-				Type:        jsonschema.String,
+				Type:        []jsonschema.DataType{jsonschema.String},
 				Description: "The city and state, e.g. San Francisco, CA",
 			},
 			"unit": {
-				Type: jsonschema.String,
+				Type: []jsonschema.DataType{jsonschema.String},
 				Enum: []string{"celsius", "fahrenheit"},
 			},
 		},

--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -28,7 +28,7 @@ const (
 // It is fairly limited, and you may have better luck using a third-party library.
 type Definition struct {
 	// Type specifies the data type of the schema.
-	Type DataType `json:"type,omitempty"`
+	Type []DataType `json:"type,omitempty"`
 	// Description is the description of the schema.
 	Description string `json:"description,omitempty"`
 	// Enum is used to restrict a value to a fixed set of values. It must be an array with at least
@@ -44,7 +44,7 @@ type Definition struct {
 	// that are not explicitly defined in the properties section of the schema. example:
 	// additionalProperties: true
 	// additionalProperties: false
-	// additionalProperties: jsonschema.Definition{Type: jsonschema.String}
+	// additionalProperties: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}
 	AdditionalProperties any `json:"additionalProperties,omitempty"`
 }
 
@@ -72,23 +72,23 @@ func reflectSchema(t reflect.Type) (*Definition, error) {
 	var d Definition
 	switch t.Kind() {
 	case reflect.String:
-		d.Type = String
+		d.Type = []DataType{String}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		d.Type = Integer
+		d.Type = []DataType{Integer}
 	case reflect.Float32, reflect.Float64:
-		d.Type = Number
+		d.Type = []DataType{Number}
 	case reflect.Bool:
-		d.Type = Boolean
+		d.Type = []DataType{Boolean}
 	case reflect.Slice, reflect.Array:
-		d.Type = Array
+		d.Type = []DataType{Array}
 		items, err := reflectSchema(t.Elem())
 		if err != nil {
 			return nil, err
 		}
 		d.Items = items
 	case reflect.Struct:
-		d.Type = Object
+		d.Type = []DataType{Object}
 		d.AdditionalProperties = false
 		object, err := reflectSchemaObject(t)
 		if err != nil {
@@ -101,6 +101,7 @@ func reflectSchema(t reflect.Type) (*Definition, error) {
 			return nil, err
 		}
 		d = *definition
+		d.Type = append(d.Type, Null)
 	case reflect.Invalid, reflect.Uintptr, reflect.Complex64, reflect.Complex128,
 		reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
 		reflect.UnsafePointer:
@@ -112,7 +113,7 @@ func reflectSchema(t reflect.Type) (*Definition, error) {
 
 func reflectSchemaObject(t reflect.Type) (*Definition, error) {
 	var d = Definition{
-		Type:                 Object,
+		Type:                 []DataType{Object},
 		AdditionalProperties: false,
 	}
 	properties := make(map[string]Definition)

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -198,3 +198,110 @@ func structToMap(t *testing.T, v any) map[string]any {
 	}
 	return got
 }
+
+type basicStruct struct {
+	Name string `json:"name"`
+}
+
+type nestedStruct struct {
+	User basicStruct `json:"user"`
+}
+
+type nullableValueStruct struct {
+	Name *string `json:"name"`
+}
+
+type arrayStruct struct {
+	Names []string `json:"names"`
+}
+
+func TestGenerateSchemaForType(t *testing.T) {
+	type args struct {
+		v any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *jsonschema.Definition
+		wantErr bool
+	}{
+		{
+			name: "Test with basic struct",
+			args: args{v: basicStruct{}},
+			want: &jsonschema.Definition{
+				Type: []jsonschema.DataType{jsonschema.Object},
+				Properties: map[string]jsonschema.Definition{
+					"name": {
+						Type: []jsonschema.DataType{jsonschema.String},
+					},
+				},
+				Required:             []string{"name"},
+				AdditionalProperties: false,
+			},
+		},
+		{
+			name: "Test with nested struct",
+			args: args{v: nestedStruct{}},
+			want: &jsonschema.Definition{
+				Type: []jsonschema.DataType{jsonschema.Object},
+				Properties: map[string]jsonschema.Definition{
+					"user": {
+						Type: []jsonschema.DataType{jsonschema.Object},
+						Properties: map[string]jsonschema.Definition{
+							"name": {
+								Type: []jsonschema.DataType{jsonschema.String},
+							},
+						},
+						Required:             []string{"name"},
+						AdditionalProperties: false,
+					},
+				},
+				Required:             []string{"user"},
+				AdditionalProperties: false,
+			},
+		},
+		{
+			name: "Test with nullable value struct",
+			args: args{v: nullableValueStruct{}},
+			want: &jsonschema.Definition{
+				Type: []jsonschema.DataType{jsonschema.Object},
+				Properties: map[string]jsonschema.Definition{
+					"name": {
+						Type: []jsonschema.DataType{jsonschema.String, jsonschema.Null},
+					},
+				},
+				Required:             []string{"name"},
+				AdditionalProperties: false,
+			},
+		},
+		{
+			name: "Test with array struct",
+			args: args{v: arrayStruct{}},
+			want: &jsonschema.Definition{
+				Type: []jsonschema.DataType{jsonschema.Object},
+				Properties: map[string]jsonschema.Definition{
+					"names": {
+						Type: []jsonschema.DataType{jsonschema.Array},
+						Items: &jsonschema.Definition{
+							Type: []jsonschema.DataType{jsonschema.String},
+						},
+					},
+				},
+				Required:             []string{"names"},
+				AdditionalProperties: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jsonschema.GenerateSchemaForType(tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateSchemaForType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GenerateSchemaForType() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -17,26 +17,25 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with empty Definition",
 			def:  jsonschema.Definition{},
-			want: `{"properties":{}}`,
+			want: `{}`,
 		},
 		{
 			name: "Test with Definition properties set",
 			def: jsonschema.Definition{
-				Type:        jsonschema.String,
+				Type:        []jsonschema.DataType{jsonschema.String},
 				Description: "A string type",
 				Properties: map[string]jsonschema.Definition{
 					"name": {
-						Type: jsonschema.String,
+						Type: []jsonschema.DataType{jsonschema.String},
 					},
 				},
 			},
 			want: `{
-   "type":"string",
+   "type":["string"],
    "description":"A string type",
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":["string"]
       }
    }
 }`,
@@ -44,34 +43,32 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with nested Definition properties",
 			def: jsonschema.Definition{
-				Type: jsonschema.Object,
+				Type: []jsonschema.DataType{jsonschema.Object},
 				Properties: map[string]jsonschema.Definition{
 					"user": {
-						Type: jsonschema.Object,
+						Type: []jsonschema.DataType{jsonschema.Object},
 						Properties: map[string]jsonschema.Definition{
 							"name": {
-								Type: jsonschema.String,
+								Type: []jsonschema.DataType{jsonschema.String},
 							},
 							"age": {
-								Type: jsonschema.Integer,
+								Type: []jsonschema.DataType{jsonschema.Integer},
 							},
 						},
 					},
 				},
 			},
 			want: `{
-   "type":"object",
+   "type":["object"],
    "properties":{
       "user":{
-         "type":"object",
+         "type":["object"],
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":["string"]
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":["integer"]
             }
          }
       }
@@ -81,25 +78,25 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with complex nested Definition",
 			def: jsonschema.Definition{
-				Type: jsonschema.Object,
+				Type: []jsonschema.DataType{jsonschema.Object},
 				Properties: map[string]jsonschema.Definition{
 					"user": {
-						Type: jsonschema.Object,
+						Type: []jsonschema.DataType{jsonschema.Object},
 						Properties: map[string]jsonschema.Definition{
 							"name": {
-								Type: jsonschema.String,
+								Type: []jsonschema.DataType{jsonschema.String},
 							},
 							"age": {
-								Type: jsonschema.Integer,
+								Type: []jsonschema.DataType{jsonschema.Integer},
 							},
 							"address": {
-								Type: jsonschema.Object,
+								Type: []jsonschema.DataType{jsonschema.Object},
 								Properties: map[string]jsonschema.Definition{
 									"city": {
-										Type: jsonschema.String,
+										Type: []jsonschema.DataType{jsonschema.String},
 									},
 									"country": {
-										Type: jsonschema.String,
+										Type: []jsonschema.DataType{jsonschema.String},
 									},
 								},
 							},
@@ -108,31 +105,27 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 				},
 			},
 			want: `{
-   "type":"object",
+   "type":["object"],
    "properties":{
       "user":{
-         "type":"object",
+         "type":["object"],
          "properties":{
-            "name":{
-               "type":"string",
-               "properties":{}
-            },
-            "age":{
-               "type":"integer",
-               "properties":{}
-            },
             "address":{
-               "type":"object",
+               "type":["object"],
                "properties":{
                   "city":{
-                     "type":"string",
-                     "properties":{}
+                     "type":["string"]
                   },
                   "country":{
-                     "type":"string",
-                     "properties":{}
+                     "type":["string"]
                   }
                }
+            },
+			"name":{
+               "type":["string"]
+            },
+            "age":{
+               "type":["integer"]
             }
          }
       }
@@ -142,28 +135,24 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with Array type Definition",
 			def: jsonschema.Definition{
-				Type: jsonschema.Array,
+				Type: []jsonschema.DataType{jsonschema.Array},
 				Items: &jsonschema.Definition{
-					Type: jsonschema.String,
+					Type: []jsonschema.DataType{jsonschema.String},
 				},
 				Properties: map[string]jsonschema.Definition{
 					"name": {
-						Type: jsonschema.String,
+						Type: []jsonschema.DataType{jsonschema.String},
 					},
 				},
 			},
 			want: `{
-   "type":"array",
+   "type":["array"],
    "items":{
-      "type":"string",
-      "properties":{
-         
-      }
+      "type":["string"]
    },
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":["string"]
       }
    }
 }`,
@@ -182,6 +171,9 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 
 			got := structToMap(t, tt.def)
 			gotPtr := structToMap(t, &tt.def)
+
+			gotBytes, err := json.Marshal(tt.def)
+			_ = gotBytes
 
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("MarshalJSON() got = %v, want %v", got, want)

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -172,9 +172,6 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 			got := structToMap(t, tt.def)
 			gotPtr := structToMap(t, &tt.def)
 
-			gotBytes, err := json.Marshal(tt.def)
-			_ = gotBytes
-
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("MarshalJSON() got = %v, want %v", got, want)
 			}

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -18,35 +18,39 @@ func VerifySchemaAndUnmarshal(schema Definition, content []byte, v any) error {
 }
 
 func Validate(schema Definition, data any) bool {
-	switch schema.Type {
-	case Object:
-		return validateObject(schema, data)
-	case Array:
-		return validateArray(schema, data)
-	case String:
-		_, ok := data.(string)
-		return ok
-	case Number: // float64 and int
-		_, ok := data.(float64)
-		if !ok {
-			_, ok = data.(int)
+	for _, dataType := range schema.Type {
+		switch dataType {
+		case Object:
+			return validateObject(schema, data)
+		case Array:
+			return validateArray(schema, data)
+		case String:
+			_, ok := data.(string)
+			return ok
+		case Number: // float64 and int
+			_, ok := data.(float64)
+			if !ok {
+				_, ok = data.(int)
+			}
+			return ok
+		case Boolean:
+			_, ok := data.(bool)
+			return ok
+		case Integer:
+			// Golang unmarshals all numbers as float64, so we need to check if the float64 is an integer
+			if num, ok := data.(float64); ok {
+				return num == float64(int64(num))
+			}
+			_, ok := data.(int)
+			return ok
+		case Null:
+			return data == nil
+		default:
+			return false
 		}
-		return ok
-	case Boolean:
-		_, ok := data.(bool)
-		return ok
-	case Integer:
-		// Golang unmarshals all numbers as float64, so we need to check if the float64 is an integer
-		if num, ok := data.(float64); ok {
-			return num == float64(int64(num))
-		}
-		_, ok := data.(int)
-		return ok
-	case Null:
-		return data == nil
-	default:
-		return false
 	}
+
+	return false
 }
 
 func validateObject(schema Definition, data any) bool {

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -29,16 +29,20 @@ func Test_Validate(t *testing.T) {
 		{"", args{data: 0, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Null}}}, false},
 		// array
 		{"", args{data: []any{"a", "b", "c"}, schema: jsonschema.Definition{
-			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}},
+			Type:  []jsonschema.DataType{jsonschema.Array},
+			Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}},
 		}, true},
 		{"", args{data: []any{1, 2, 3}, schema: jsonschema.Definition{
-			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}},
+			Type:  []jsonschema.DataType{jsonschema.Array},
+			Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}},
 		}, false},
 		{"", args{data: []any{1, 2, 3}, schema: jsonschema.Definition{
-			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}},
+			Type:  []jsonschema.DataType{jsonschema.Array},
+			Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}},
 		}, true},
 		{"", args{data: []any{1, 2, 3.4}, schema: jsonschema.Definition{
-			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}},
+			Type:  []jsonschema.DataType{jsonschema.Array},
+			Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}},
 		}, false},
 		// object
 		{"", args{data: map[string]any{
@@ -47,13 +51,17 @@ func Test_Validate(t *testing.T) {
 			"number":  123.4,
 			"boolean": false,
 			"array":   []any{1, 2, 3},
-		}, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Object}, Properties: map[string]jsonschema.Definition{
-			"string":  {Type: []jsonschema.DataType{jsonschema.String}},
-			"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
-			"number":  {Type: []jsonschema.DataType{jsonschema.Number}},
-			"boolean": {Type: []jsonschema.DataType{jsonschema.Boolean}},
-			"array":   {Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}}},
-		},
+		}, schema: jsonschema.Definition{
+			Type: []jsonschema.DataType{jsonschema.Object}, Properties: map[string]jsonschema.Definition{
+				"string":  {Type: []jsonschema.DataType{jsonschema.String}},
+				"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
+				"number":  {Type: []jsonschema.DataType{jsonschema.Number}},
+				"boolean": {Type: []jsonschema.DataType{jsonschema.Boolean}},
+				"array": {
+					Type:  []jsonschema.DataType{jsonschema.Array},
+					Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}},
+				},
+			},
 			Required: []string{"string"},
 		}}, true},
 		{"", args{data: map[string]any{
@@ -61,13 +69,17 @@ func Test_Validate(t *testing.T) {
 			"number":  123.4,
 			"boolean": false,
 			"array":   []any{1, 2, 3},
-		}, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Object}, Properties: map[string]jsonschema.Definition{
-			"string":  {Type: []jsonschema.DataType{jsonschema.String}},
-			"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
-			"number":  {Type: []jsonschema.DataType{jsonschema.Number}},
-			"boolean": {Type: []jsonschema.DataType{jsonschema.Boolean}},
-			"array":   {Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}}},
-		},
+		}, schema: jsonschema.Definition{
+			Type: []jsonschema.DataType{jsonschema.Object}, Properties: map[string]jsonschema.Definition{
+				"string":  {Type: []jsonschema.DataType{jsonschema.String}},
+				"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
+				"number":  {Type: []jsonschema.DataType{jsonschema.Number}},
+				"boolean": {Type: []jsonschema.DataType{jsonschema.Boolean}},
+				"array": {
+					Type:  []jsonschema.DataType{jsonschema.Array},
+					Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}},
+				},
+			},
 			Required: []string{"string"},
 		}}, false},
 	}

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -17,28 +17,28 @@ func Test_Validate(t *testing.T) {
 		want bool
 	}{
 		// string integer number boolean
-		{"", args{data: "ABC", schema: jsonschema.Definition{Type: jsonschema.String}}, true},
-		{"", args{data: 123, schema: jsonschema.Definition{Type: jsonschema.String}}, false},
-		{"", args{data: 123, schema: jsonschema.Definition{Type: jsonschema.Integer}}, true},
-		{"", args{data: 123.4, schema: jsonschema.Definition{Type: jsonschema.Integer}}, false},
-		{"", args{data: "ABC", schema: jsonschema.Definition{Type: jsonschema.Number}}, false},
-		{"", args{data: 123, schema: jsonschema.Definition{Type: jsonschema.Number}}, true},
-		{"", args{data: false, schema: jsonschema.Definition{Type: jsonschema.Boolean}}, true},
-		{"", args{data: 123, schema: jsonschema.Definition{Type: jsonschema.Boolean}}, false},
-		{"", args{data: nil, schema: jsonschema.Definition{Type: jsonschema.Null}}, true},
-		{"", args{data: 0, schema: jsonschema.Definition{Type: jsonschema.Null}}, false},
+		{"", args{data: "ABC", schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}}, true},
+		{"", args{data: 123, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}}, false},
+		{"", args{data: 123, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}}, true},
+		{"", args{data: 123.4, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}}, false},
+		{"", args{data: "ABC", schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}}}, false},
+		{"", args{data: 123, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}}}, true},
+		{"", args{data: false, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Boolean}}}, true},
+		{"", args{data: 123, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Boolean}}}, false},
+		{"", args{data: nil, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Null}}}, true},
+		{"", args{data: 0, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Null}}}, false},
 		// array
 		{"", args{data: []any{"a", "b", "c"}, schema: jsonschema.Definition{
-			Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.String}},
+			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}},
 		}, true},
 		{"", args{data: []any{1, 2, 3}, schema: jsonschema.Definition{
-			Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.String}},
+			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.String}}},
 		}, false},
 		{"", args{data: []any{1, 2, 3}, schema: jsonschema.Definition{
-			Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Integer}},
+			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}},
 		}, true},
 		{"", args{data: []any{1, 2, 3.4}, schema: jsonschema.Definition{
-			Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Integer}},
+			Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Integer}}},
 		}, false},
 		// object
 		{"", args{data: map[string]any{
@@ -47,12 +47,12 @@ func Test_Validate(t *testing.T) {
 			"number":  123.4,
 			"boolean": false,
 			"array":   []any{1, 2, 3},
-		}, schema: jsonschema.Definition{Type: jsonschema.Object, Properties: map[string]jsonschema.Definition{
-			"string":  {Type: jsonschema.String},
-			"integer": {Type: jsonschema.Integer},
-			"number":  {Type: jsonschema.Number},
-			"boolean": {Type: jsonschema.Boolean},
-			"array":   {Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Number}},
+		}, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Object}, Properties: map[string]jsonschema.Definition{
+			"string":  {Type: []jsonschema.DataType{jsonschema.String}},
+			"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
+			"number":  {Type: []jsonschema.DataType{jsonschema.Number}},
+			"boolean": {Type: []jsonschema.DataType{jsonschema.Boolean}},
+			"array":   {Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}}},
 		},
 			Required: []string{"string"},
 		}}, true},
@@ -61,12 +61,12 @@ func Test_Validate(t *testing.T) {
 			"number":  123.4,
 			"boolean": false,
 			"array":   []any{1, 2, 3},
-		}, schema: jsonschema.Definition{Type: jsonschema.Object, Properties: map[string]jsonschema.Definition{
-			"string":  {Type: jsonschema.String},
-			"integer": {Type: jsonschema.Integer},
-			"number":  {Type: jsonschema.Number},
-			"boolean": {Type: jsonschema.Boolean},
-			"array":   {Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Number}},
+		}, schema: jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Object}, Properties: map[string]jsonschema.Definition{
+			"string":  {Type: []jsonschema.DataType{jsonschema.String}},
+			"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
+			"number":  {Type: []jsonschema.DataType{jsonschema.Number}},
+			"boolean": {Type: []jsonschema.DataType{jsonschema.Boolean}},
+			"array":   {Type: []jsonschema.DataType{jsonschema.Array}, Items: &jsonschema.Definition{Type: []jsonschema.DataType{jsonschema.Number}}},
 		},
 			Required: []string{"string"},
 		}}, false},
@@ -93,10 +93,10 @@ func TestUnmarshal(t *testing.T) {
 	}{
 		{"", args{
 			schema: jsonschema.Definition{
-				Type: jsonschema.Object,
+				Type: []jsonschema.DataType{jsonschema.Object},
 				Properties: map[string]jsonschema.Definition{
-					"string": {Type: jsonschema.String},
-					"number": {Type: jsonschema.Number},
+					"string": {Type: []jsonschema.DataType{jsonschema.String}},
+					"number": {Type: []jsonschema.DataType{jsonschema.Number}},
 				},
 			},
 			content: []byte(`{"string":"abc","number":123.4}`),
@@ -107,10 +107,10 @@ func TestUnmarshal(t *testing.T) {
 		}, false},
 		{"", args{
 			schema: jsonschema.Definition{
-				Type: jsonschema.Object,
+				Type: []jsonschema.DataType{jsonschema.Object},
 				Properties: map[string]jsonschema.Definition{
-					"string": {Type: jsonschema.String},
-					"number": {Type: jsonschema.Number},
+					"string": {Type: []jsonschema.DataType{jsonschema.String}},
+					"number": {Type: []jsonschema.DataType{jsonschema.Number}},
 				},
 				Required: []string{"string", "number"},
 			},
@@ -122,10 +122,10 @@ func TestUnmarshal(t *testing.T) {
 		}, true},
 		{"validate integer", args{
 			schema: jsonschema.Definition{
-				Type: jsonschema.Object,
+				Type: []jsonschema.DataType{jsonschema.Object},
 				Properties: map[string]jsonschema.Definition{
-					"string":  {Type: jsonschema.String},
-					"integer": {Type: jsonschema.Integer},
+					"string":  {Type: []jsonschema.DataType{jsonschema.String}},
+					"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
 				},
 				Required: []string{"string", "integer"},
 			},
@@ -137,10 +137,10 @@ func TestUnmarshal(t *testing.T) {
 		}, false},
 		{"validate integer failed", args{
 			schema: jsonschema.Definition{
-				Type: jsonschema.Object,
+				Type: []jsonschema.DataType{jsonschema.Object},
 				Properties: map[string]jsonschema.Definition{
-					"string":  {Type: jsonschema.String},
-					"integer": {Type: jsonschema.Integer},
+					"string":  {Type: []jsonschema.DataType{jsonschema.String}},
+					"integer": {Type: []jsonschema.DataType{jsonschema.Integer}},
 				},
 				Required: []string{"string", "integer"},
 			},


### PR DESCRIPTION
Changes Definition.Type from DataType to []DataType

Why?

* Allows for more fine-grained control of types
* Allows for pointers to be treated as nullable
* Fixes issue with empty properties object being omitted when marshaling